### PR TITLE
Add `--version` flag to CLI

### DIFF
--- a/app/Nbparts/Cli/Options.hs
+++ b/app/Nbparts/Cli/Options.hs
@@ -1,6 +1,7 @@
 module Nbparts.Cli.Options where
 
 import Control.Monad.Error.Class (throwError)
+import Data.Version qualified as Version
 import Nbparts.Pack (PackOptions (PackOptions))
 import Nbparts.Run (Command (Pack, Unpack), Options (Options))
 import Nbparts.Types (Format (FormatJson, FormatMarkdown, FormatYaml))
@@ -15,8 +16,10 @@ import Options.Applicative
     fullDesc,
     help,
     helper,
+    hidden,
     hsubparser,
     info,
+    infoOption,
     long,
     metavar,
     option,
@@ -29,6 +32,7 @@ import Options.Applicative
     strOption,
     value,
   )
+import Paths_nbparts qualified
 
 unpackOptionsParser :: Parser UnpackOptions
 unpackOptionsParser =
@@ -100,5 +104,9 @@ parseOpts :: IO Options
 parseOpts =
   customExecParser (prefs showHelpOnEmpty) $
     info
-      (helper <*> nbpartsOptionsParser)
+      (helper <*> versioner <*> nbpartsOptionsParser)
       (fullDesc <> progDesc "Unpack a Jupyter notebook into its sources, metadata and outputs")
+  where
+    versioner =
+      infoOption (Version.showVersion Paths_nbparts.version) $
+        short 'V' <> long "version" <> help "Show nbparts version" <> hidden

--- a/nbparts.cabal
+++ b/nbparts.cabal
@@ -105,6 +105,9 @@ executable nbparts
     main-is: Main.hs
     other-modules:
         Nbparts.Cli.Options
+        Paths_nbparts
+    autogen-modules:
+        Paths_nbparts
     build-depends:
         nbparts,
         base >=4.19 && <5,


### PR DESCRIPTION
Adds a `--version` (short: `-V`) flag to the CLI to check the current `nbparts` version.