### PR TITLE
Relax manifest version checks

### DIFF
--- a/src/Nbparts/Pack.hs
+++ b/src/Nbparts/Pack.hs
@@ -170,6 +170,8 @@ checkVersion nbpartsVersion = do
       maybeMajorB = branch !? 1
       maybeMinor = branch !? 2
       maybePatch = branch !? 3
+      maybeInvalid = branch !? 4 -- We want this to be Nothing.
+  Monad.when (Maybe.isJust maybeInvalid) $ throwError (PackManifestUnknownVersionError version)
 
   (majorA, majorB, minor, patch) <- case (,,,) <$> maybeMajorA <*> maybeMajorB <*> maybeMinor <*> maybePatch of
     Just branches -> pure branches

--- a/src/Nbparts/Types/Error.hs
+++ b/src/Nbparts/Types/Error.hs
@@ -8,7 +8,6 @@ import Data.Text qualified as Text
 import Data.Version qualified as Data
 import Data.Version qualified as Version
 import Data.Yaml qualified as Yaml
-import Nbparts.Types.Manifest (currentNbpartsVersion)
 import Nbparts.Types.Manifest qualified as Manifest
 import Text.Megaparsec qualified as Megaparsec
 import Text.Parsec (errorPos)
@@ -30,8 +29,6 @@ data PackError
   = PackUnsupportedNotebookFormat (Int, Int)
   | PackParseManifestError ParseYamlError
   | PackManifestUnknownVersionError Data.Version
-  | PackManifestTooNewError Data.Version
-  | PackManifestTooOldError Data.Version
   | PackIllegalFormatError IllegalFormatContext Manifest.Format
   | PackParseYamlSourcesError ParseYamlError
   | PackParseJsonSourcesError Text
@@ -98,18 +95,6 @@ renderError err = case err of
       <> Text.pack (show minor)
   PackError (PackParseManifestError (ParseYamlError ex)) -> "Failed to parse manifest: " <> Text.pack (Exception.displayException ex)
   PackError (PackManifestUnknownVersionError version) -> "Unknown manifest version: " <> Text.pack (Version.showVersion version)
-  PackError (PackManifestTooNewError version) ->
-    "Manifest version ("
-      <> Text.pack (Version.showVersion version)
-      <> ") is too new for the current nbparts ("
-      <> Text.pack (Version.showVersion currentNbpartsVersion)
-      <> ")"
-  PackError (PackManifestTooOldError version) ->
-    "Manifest version ("
-      <> Text.pack (Version.showVersion version)
-      <> ") is too old for the current nbparts ("
-      <> Text.pack (Version.showVersion currentNbpartsVersion)
-      <> ")"
   PackError (PackIllegalFormatError ctx fmt) -> "Illegal format for " <> renderIllegalFormatContext ctx <> ":" <> renderFormat fmt
   PackError (PackParseYamlSourcesError (ParseYamlError ex)) -> "Failed to parse sources: " <> Text.pack (Exception.displayException ex)
   PackError (PackParseJsonSourcesError parseErr) -> "Failed to parse sources: " <> parseErr


### PR DESCRIPTION
The manifest version checks when packing were too strict — `nbparts` would exit with an error message if the manifest version had a different major version. However, we should still at least try packing the parts since a change in `nbparts`'s major version does not necessarily mean that the unpack format has changed (e.g., removal of a CLI option does not affect the unpack format). Maybe the unpack format should be versioned separately?

In any case, this PR relaxes the version checks so that we warn instead of error out if the major versions mismatch.