### PR TITLE
[CI] Test with GHC 9.10 and 9.12

### DIFF
--- a/nbparts.cabal
+++ b/nbparts.cabal
@@ -23,6 +23,8 @@ bug-reports: https://github.com/dixslyf/nbparts/issues
 category: Data
 tested-with:
     GHC == 9.8
+    GHC == 9.10
+    GHC == 9.12
 build-type: Simple
 extra-doc-files:
     CHANGELOG.md


### PR DESCRIPTION
Previously, `nbparts` was only tested against GHC 9.8. This PR adds 9.10 and 9.12 to the matrix.