### PR TITLE
Fix incorrect serialisation of `FormatJson`

### DIFF
--- a/src/Nbparts/Types/Manifest.hs
+++ b/src/Nbparts/Types/Manifest.hs
@@ -9,6 +9,7 @@ where
 
 import Data.Aeson (Options (constructorTagModifier))
 import Data.Aeson qualified as Aeson
+import Data.Text qualified as Text
 import Data.Version (Version)
 import GHC.Generics (Generic)
 import Paths_nbparts qualified
@@ -44,23 +45,32 @@ formatExtension FormatYaml = "yaml"
 formatExtension FormatJson = "json"
 formatExtension FormatMarkdown = "md"
 
-instance Aeson.ToJSON Manifest where
-  toJSON = Aeson.genericToJSON jsonOptions
+instance Aeson.ToJSON Manifest
 
-instance Aeson.FromJSON Manifest where
-  parseJSON = Aeson.genericParseJSON jsonOptions
+instance Aeson.FromJSON Manifest
 
 instance Aeson.ToJSON Format where
   toJSON = Aeson.genericToJSON jsonOptions
 
 instance Aeson.FromJSON Format where
-  parseJSON = Aeson.genericParseJSON jsonOptions
+  parseJSON = Aeson.withText "Format" $ \case
+    "yaml" -> pure FormatYaml
+    "json" -> pure FormatJson
+    "markdown" -> pure FormatMarkdown
+    -- Backward compatibility. v0.1.0.0 mistakenly serialised `FormatJson` as
+    -- "FormatJson" instead of "json", so now we're stuck with dealing with that.
+    -- For symmetry's sake, might as well include the rest of the formats as well.
+    "FormatYaml" -> pure FormatYaml
+    "FormatJson" -> pure FormatJson
+    "FormatMarkdown" -> pure FormatMarkdown
+    other -> fail $ "Unknown format: " <> Text.unpack other
 
 jsonOptions :: Aeson.Options
 jsonOptions =
   Aeson.defaultOptions
     { constructorTagModifier = \case
         "FormatYaml" -> "yaml"
+        "FormatJson" -> "json"
         "FormatMarkdown" -> "markdown"
         other -> other
     }


### PR DESCRIPTION
`FormatJson` was incorrectly serialised as `"FormatJson"` instead of `"json"`, so it did not fit in with `FormatYaml -> "yaml"` and `FormatMarkdown -> "markdown"`. This PR fixes that and also adds backward compatibility so that `"FormatJson"` can still be
deserialised to `FormatJson`. For symmetry, `"FormatYaml"` and `"FormatMarkdown"` can now also be deserialised to `FormatYaml` and `FormatMarkdown` respectively.

Tests have been added to ensure backward compatibility.
