### PR TITLE
Allow packing when outputs are missing

### DIFF
--- a/src/Nbparts/Types/Outputs.hs
+++ b/src/Nbparts/Types/Outputs.hs
@@ -16,10 +16,10 @@ import GHC.Generics (Generic)
 import Nbparts.Types.Mime (UnembeddedMimeBundle)
 
 newtype NotebookOutputs a = NotebookOutputs (Map Text [Ipynb.Output a]) -- Map of Cell IDs to outputs.
-  deriving (Generic, Show, Eq)
+  deriving (Generic, Show, Eq, Semigroup, Monoid)
 
 newtype UnembeddedNotebookOutputs = UnembeddedNotebookOutputs (Map Text [UnembeddedCellOutput])
-  deriving (Generic, Show, Eq, Ord)
+  deriving (Generic, Show, Eq, Ord, Semigroup, Monoid)
 
 data UnembeddedCellOutput
   = Stream


### PR DESCRIPTION
Instead of erroring out when the outputs file is missing, `nbparts` will now only warn and assume that the notebook has no outputs. This is convenient when, e.g., you check in the sources and metadata to source control, but not the outputs.